### PR TITLE
Require C11 standard

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,7 @@ project(swipl-pack-environ)
 # Include swipl.cmake from the running SWI-Prolog's home
 list(INSERT CMAKE_MODULE_PATH 0 $ENV{SWIPL_HOME_DIR}/cmake)
 include(swipl)
+set(CMAKE_C_STANDARD 11) # see comment in environ.c
 
 # Create the library as a CMake module
 add_library(environ MODULE c/environ.c)

--- a/c/environ.c
+++ b/c/environ.c
@@ -5,7 +5,7 @@ static functor_t FUNCTOR_equal2;
 #define MAXNAME 512
 
 static foreign_t
-pl_environ(term_t list)
+pl_environ(term_t list) # cast to pl_function_t requires C11
 { extern char **environ;
   term_t tail = PL_copy_term_ref(list);
   term_t head = PL_new_term_ref();

--- a/c/environ.c
+++ b/c/environ.c
@@ -5,7 +5,7 @@ static functor_t FUNCTOR_equal2;
 #define MAXNAME 512
 
 static foreign_t
-pl_environ(term_t list) # cast to pl_function_t requires C11
+pl_environ(term_t list) // cast to pl_function_t requires C11
 { extern char **environ;
   term_t tail = PL_copy_term_ref(list);
   term_t head = PL_new_term_ref();


### PR DESCRIPTION
The cast from foreign_t with argument term_t to the declaration pl_function_t requires C11